### PR TITLE
refactor: unify logging system to use tracing exclusively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ thiserror = "1.0"
 
 # Logging
 log = "0.4"
-env_logger = "0.10"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time", "chrono"] }
+tracing-log = "0.2"
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }
@@ -58,7 +60,6 @@ regex = "1.11"
 
 # Futures utilities
 futures = "0.3"
-tracing = "0.1.41"
 
 # Cryptography for Feishu signature
 hmac = "0.12"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3,7 +3,7 @@
 //! 使用clap定义应用程序的命令行接口
 
 use clap::{Parser, Subcommand, ValueEnum};
-use log::error;
+use tracing::error;
 use std::path::PathBuf;
 
 /// Service Vitals - 跨平台服务健康监控工具

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -147,8 +147,8 @@ impl ConfigLoader for TomlConfigLoader {
         // 验证配置
         self.validate(&config)?;
 
-        log::info!("成功加载配置文件: {}", path.display());
-        log::debug!("配置内容: {:?}", config);
+        tracing::info!("成功加载配置文件: {}", path.display());
+        tracing::debug!("配置内容: {:?}", config);
 
         Ok(config)
     }
@@ -160,7 +160,7 @@ impl ConfigLoader for TomlConfigLoader {
         // 验证配置
         self.validate(&config)?;
 
-        log::debug!("成功解析配置字符串");
+        tracing::debug!("成功解析配置字符串");
 
         Ok(config)
     }

--- a/src/daemon/service_manager.rs
+++ b/src/daemon/service_manager.rs
@@ -6,7 +6,7 @@
 use crate::daemon::PlatformDaemonManager;
 use crate::daemon::{DaemonConfig, DaemonManager, DaemonStatus};
 use crate::error::Result;
-use log::{error, info};
+use tracing::{error, info};
 use serde::{Deserialize, Serialize};
 
 /// 服务管理器

--- a/src/daemon/signal_handler.rs
+++ b/src/daemon/signal_handler.rs
@@ -3,7 +3,7 @@
 //! 提供Linux/Unix信号处理和优雅关闭支持
 
 use crate::error::Result;
-use log::{error, info, warn};
+use tracing::{error, info, warn};
 use tokio::sync::broadcast;
 
 #[cfg(unix)]

--- a/src/daemon/unix.rs
+++ b/src/daemon/unix.rs
@@ -5,7 +5,7 @@
 use crate::daemon::{DaemonConfig, DaemonManager, DaemonStatus};
 use crate::error::{Result, ServiceVitalsError};
 use async_trait::async_trait;
-use log::{debug, error, info, warn};
+use tracing::{debug, error, info, warn};
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;


### PR DESCRIPTION
## 🔄 日志系统统一重构

本 PR 完全统一了项目的日志系统，从混合使用 `log` 和 `tracing` 迁移到仅使用 `tracing` 作为单一日志框架。

### 🎨 问题背景

在之前的代码分析中发现，项目中同时使用了两套日志系统：

**使用 `log` crate 的模块**:
- `src/cli/args.rs`
- `src/daemon/service_manager.rs`
- `src/daemon/signal_handler.rs`
- `src/daemon/unix.rs`
- `src/config/loader.rs`
- `src/logging.rs` (核心日志配置模块)

**使用 `tracing` crate 的模块**:
- `src/config/manager.rs`
- `src/config/watcher.rs`
- `src/health/scheduler.rs`
- `src/main.rs`
- `src/notification/feishu.rs`

这种混用导致了以下问题：
- 日志输出不一致
- 日志级别控制可能失效
- 结构化日志特性丢失
- 额外的性能开销

### 🔧 解决方案

#### 1️⃣ **依赖管理更新** (Cargo.toml)
```toml
# 新增的依赖
+ tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time", "chrono"] }
+ tracing-log = "0.2"

# 移除的依赖
- env_logger = "0.10"

# 保留的依赖（兼容性）
log = "0.4"
tracing = "0.1.41"
```

#### 2️⃣ **核心日志模块重构** (src/logging.rs)

**主要改进**:
- ✅ 将 `env_logger` 替换为 `tracing-subscriber`
- ✅ 添加 `LogTracer::init()` 实现 log 到 tracing 的桥接
- ✅ 实现适当的 `EnvFilter` 用于级别和模块过滤
- ✅ 支持控制台和文件输出，带有适当的格式化
- ✅ 保持所有现有的 `LogConfig` 结构和公共接口
- ✅ 保留所有特殊日志功能：`audit_log`、`performance_log`、`health_status_log`、`notification_log` 和指标收集

**技术实现细节**:
```rust
// 日志桥接设置
LogTracer::init().ok(); // 忽略重复初始化错误

// 环境过滤器配置
let mut env_filter = EnvFilter::from_default_env()
    .add_directive(Self::convert_level_to_directive(config.level));

// 格式化层配置
let fmt_layer = if config.json_format {
    fmt::layer().json().with_timer(fmt::time::ChronoUtc::rfc_3339())
} else {
    fmt::layer().with_timer(fmt::time::ChronoUtc::rfc_3339())
};

// 安全初始化
registry().with(env_filter).with(fmt_layer).try_init()
```

#### 3️⃣ **模块级别日志统一**

更新以下模块使用 `tracing` 宏而非 `log` 宏：

| 模块 | 修改内容 |
|------|----------|
| `src/cli/args.rs` | `log::error` → `tracing::error` |
| `src/daemon/service_manager.rs` | `log::{error, info}` → `tracing::{error, info}` |
| `src/daemon/signal_handler.rs` | `log::{error, info, warn}` → `tracing::{error, info, warn}` |
| `src/daemon/unix.rs` | `log::{debug, error, info, warn}` → `tracing::{debug, error, info, warn}` |
| `src/config/loader.rs` | `log::info!`, `log::debug!` → `tracing::info!`, `tracing::debug!` |

#### 4️⃣ **向后兼容性保证**

- ✅ 所有现有的 `LogConfig` 选项继续正常工作
- ✅ 日志输出格式与之前的实现保持一致
- ✅ 所有命令行参数和环境变量按预期工作
- ✅ 现有的审计、性能、健康和通知日忕得到保留

### 🚀 改进效果

#### 性能优化
- **单一框架**: 消除了两套日志系统的开销
- **更好的缓存**: `tracing-subscriber` 提供更高效的日志处理
- **结构化日志**: 支持更高级的结构化日忕功能

#### 代码质量
- **一致性**: 所有模块使用相同的日忕接口
- **可维护性**: 统一的日忕配置和管理
- **可扩展性**: 为未来添加追踪和监控功能奠定基础

#### 功能增强
- **更好的调试**: `tracing` 的 span 和 event 模型
- **结构化日忕**: 支持 JSON 和结构化输出
- **高级过滤**: 更灵活的模块和级别过滤

### 🧪 验证结果

```bash
# 编译验证
✅ cargo check - 通过
✅ cargo clippy -- -D warnings - 0 警告

# 功能验证
✅ 所有日忕级别正常工作 (debug, info, warn, error)
✅ 控制台和文件输出功能正常
✅ 模块级别过滤通过 RUST_LOG 环境变量正常工作
✅ 所有现有功能得到保留
```

**日忕输出示例**:
```
[2025-07-10T07:28:54.587326174+00:00] [INFO] main ThreadId(01) service_vitals::logging:src/logging.rs:296: 日忕系统初始化完成
[2025-07-10T07:28:54.588200794+00:00] [DEBUG] main ThreadId(01) service_vitals::logging:src/logging.rs:297: 日忕配置: LogConfig { level: Debug, ... }
[2025-07-10T07:28:54.588498001+00:00] [INFO] main ThreadId(01) service_vitals:src/main.rs:41: Service Vitals v0.1.0 启动
```

### 📝 技术细节

#### 关键技术决策
1. **选择 `tracing` 作为统一框架**: `tracing` 是 `log` 的超集，提供更丰富的功能
2. **保持 `log` 兼容性**: 通过 `tracing-log` 实现向后兼容
3. **渐进式迁移**: 保持所有现有接口不变，只改变底层实现

#### 错误处理
- 对重复初始化错误进行了适当处理
- 使用 `try_init()` 而非 `init()` 避免 panic
- 添加了适当的警告日忕用于调试

### 🔍 影响评估

- **功能性**: ✅ 无破坏性变更
- **性能**: ⬆️ 轻微提升（单一框架，更高效的处理）
- **内存**: ⬇️ 减少重复的日忕系统开销
- **维护性**: ⬆️ 显著改善（统一的日忕系统）
- **可扩展性**: ⬆️ 为未来的追踪和监控功能奠定基础

---

**总结**: 这是一个重要的架构改进，通过统一日忕系统解决了代码不一致性问题，提升了整体代码质量和可维护性，同时保持了完全的向后兼容性。

---
Pull Request created by [Augment Code](https://www.augmentcode.com/) with comprehensive logging system unification

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author